### PR TITLE
Build wheels from src distributions

### DIFF
--- a/python/pip_install/extract_wheels/lib/BUILD
+++ b/python/pip_install/extract_wheels/lib/BUILD
@@ -18,6 +18,9 @@ py_library(
     deps = [
         requirement("pkginfo"),
         requirement("setuptools"),
+        requirement("build"),
+        requirement("pep517"),
+        reqyurement("tomli"),
     ],
 )
 

--- a/python/pip_install/extract_wheels/lib/bazel.py
+++ b/python/pip_install/extract_wheels/lib/bazel.py
@@ -4,13 +4,14 @@ import os
 import shutil
 import tarfile
 import textwrap
-import pkg_resources
-from distutils.core import run_setup
 
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Set
 
 from python.pip_install.extract_wheels.lib import namespace_pkgs, purelib, wheel
+
+from build import ProjectBuilder
+
 
 WHEEL_FILE_LABEL = "whl"
 PY_LIBRARY_LABEL = "pkg"
@@ -401,8 +402,16 @@ def extract_wheel(
     return None
 
 
-def extract_source(source_dist: str, incremental_repo_prefix: str) -> Optional[str]:
-    """Extracts source dist into given directory and creates py_library and filegroup targets.
+def extract_source(
+    source_dist: str,
+    extras: Dict[str, Set[str]],
+    pip_data_exclude: List[str],
+    enable_implicit_namespace_pkgs: bool,
+    incremental: bool = False,
+    incremental_repo_prefix: Optional[str] = None,
+) -> Optional[str]:
+    """Extracts source dist into given directory and builds a wheel for the
+    distribution.
 
     Returns:
         The Bazel label for the extracted wheel, in the form '//path/to/wheel'.
@@ -414,58 +423,20 @@ def extract_source(source_dist: str, incremental_repo_prefix: str) -> Optional[s
             if len(dir_components) == 1:
                 yield member
             new_path = "/".join(dir_components[1:])
-            if new_path.startswith("test"):
-                continue
             member.path = new_path
             yield member
 
     with tarfile.open(source_dist, "r:gz") as tf:
         tf.extractall(members=_members(tf))
 
-    result = run_setup("./setup.py", stop_after="init")
+    builder = ProjectBuilder(srcdir=".")
+    whl = builder.build("wheel", "_out")
 
-    # this parse out any custom package directories such as src/
-    # if there is a custom package directory, it needs to be added
-    # to the imports attribute. if no package directories are found
-    # we can assume the root directory should be used.
-    imports = []
-    if result.package_dir:
-        for k in result.package_dir.values():
-            imports.append(k)
-    if len(imports) == 0:
-        imports.append(".")
-    import_str = ",".join(['"{}"'.format(i) for i in imports])
-
-    # extract package dependencies
-    deps = []
-    if hasattr(result, "install_requires"):
-        for r in result.install_requires:
-            for d in pkg_resources.parse_requirements(r):
-                pkg_name = sanitised_repo_library_label(
-                    d.name, repo_prefix=incremental_repo_prefix
-                )
-                deps.append(pkg_name)
-    deps_str = ",".join(deps)
-
-    build_file_contents = textwrap.dedent(
-        """\
-        load("@rules_python//python:defs.bzl", "py_library")
-
-        package(default_visibility = ["//visibility:public"])
-
-        py_library(
-            name = "pkg",
-            srcs = glob(["**/*.py"], exclude=["tests/**", "*/tests/**", "setup.py"]),
-            data = glob(["**/*"], exclude=["**/*.py", "**/* *", "BUILD", "WORKSPACE"]),
-            deps = [{deps}],
-            # This makes this directory a top-level in the python import
-            # search path for anything that depends on this.
-            imports = [{imports}],
-        )
-        """.format(
-            imports=import_str, deps=deps_str
-        )
+    return extract_wheel(
+        whl,
+        extras,
+        pip_data_exclude,
+        enable_implicit_namespace_pkgs,
+        incremental,
+        incremental_repo_prefix,
     )
-
-    with open("BUILD.bazel", "w+") as build_file:
-        build_file.write(build_file_contents)

--- a/python/pip_install/parse_requirements_to_bzl/extract_single_wheel/__init__.py
+++ b/python/pip_install/parse_requirements_to_bzl/extract_single_wheel/__init__.py
@@ -36,7 +36,7 @@ def main() -> None:
 
     pip_args.extend(["--no-deps"] + deserialized_args["extra_pip_args"])
 
-    requirement_file = NamedTemporaryFile(mode='wb', delete=False)
+    requirement_file = NamedTemporaryFile(mode="wb", delete=False)
     try:
         requirement_file.write(args.requirement.encode("utf-8"))
         requirement_file.flush()
@@ -80,10 +80,14 @@ def main() -> None:
             deserialized_args["pip_data_exclude"],
             args.enable_implicit_namespace_pkgs,
             incremental=True,
-            incremental_repo_prefix=bazel.whl_library_repo_prefix(args.repo)
+            incremental_repo_prefix=bazel.whl_library_repo_prefix(args.repo),
         )
     if dist.endswith(".tar.gz"):
         bazel.extract_source(
             dist,
-            incremental_repo_prefix=bazel.whl_library_repo_prefix(args.repo)
+            extras,
+            deserialized_args["pip_data_exclude"],
+            args.enable_implicit_namespace_pkgs,
+            incremental=True,
+            incremental_repo_prefix=bazel.whl_library_repo_prefix(args.repo),
         )

--- a/python/pip_install/repositories.bzl
+++ b/python/pip_install/repositories.bzl
@@ -34,6 +34,21 @@ _RULE_DEPS = [
         "https://files.pythonhosted.org/packages/65/63/39d04c74222770ed1589c0eaba06c05891801219272420b40311cd60c880/wheel-0.36.2-py2.py3-none-any.whl",
         "78b5b185f0e5763c26ca1e324373aadd49182ca90e825f7853f4b2509215dc0e",
     ),
+    (
+        "pypi__build",
+        "https://files.pythonhosted.org/packages/46/28/70768d6585162eb29df181aed4c1adb3081307ad46a892c390dab549dc13/build-0.7.0-py3-none-any.whl",
+        "21b7ebbd1b22499c4dac536abc7606696ea4d909fd755e00f09f3c0f2c05e3c8",
+    ),
+    (
+        "pypi__pep517",
+        "https://files.pythonhosted.org/packages/f4/67/846c08e18fefb265a66e6fd5a34269d649b779718d9bf59622085dabd370/pep517-0.12.0-py2.py3-none-any.whl",
+        "dd884c326898e2c6e11f9e0b64940606a93eb10ea022a2e067959f3a110cf161",
+    ),
+    (
+        "pypi__tomli",
+        "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl",
+        "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+    ),
 ]
 
 _GENERIC_WHEEL = """\


### PR DESCRIPTION
`distutils` functionality changed when upgrading from python 3.7 to 3.9 and broke `extract_source`. This removes the hack to generate a `py_library` target from a source distribution, and instead uses https://github.com/pypa/build (a new pep 517 compliant build frontend) to build wheels from source distributions when the wheel doesn't exist.